### PR TITLE
Refactor: Improves BottomBarButton padding logic.

### DIFF
--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.text.style.TextOverflow
@@ -58,6 +59,7 @@ import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.SPACING_SMALL
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.TopSpacing
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.Z_STICKY
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.screenPaddings
+import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.stickyBottomPaddings
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.wrap.WrapIcon
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.wrap.WrapIconButton
 
@@ -181,7 +183,12 @@ internal fun ContentScreen(
                                 .zIndex(Z_STICKY),
                             contentAlignment = Alignment.Center
                         ) {
-                            stickyBottomContent(screenPaddings(padding))
+                            stickyBottomContent(
+                                stickyBottomPaddings(
+                                    contentScreenPaddings = screenPaddings(padding),
+                                    layoutDirection = LocalLayoutDirection.current
+                                )
+                            )
                         }
                     }
                 }

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/utils/ScreenPadding.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/utils/ScreenPadding.kt
@@ -17,6 +17,9 @@
 package eu.europa.ec.eudi.rqesui.presentation.ui.component.utils
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
 internal enum class TopSpacing {
@@ -32,6 +35,18 @@ internal fun screenPaddings(
     end = SPACING_LARGE.dp,
     bottom = SPACING_LARGE.dp + (append?.calculateBottomPadding() ?: 0.dp)
 )
+
+internal fun stickyBottomPaddings(
+    contentScreenPaddings: PaddingValues,
+    layoutDirection: LayoutDirection
+): PaddingValues {
+    return PaddingValues(
+        start = contentScreenPaddings.calculateStartPadding(layoutDirection),
+        end = contentScreenPaddings.calculateEndPadding(layoutDirection),
+        top = contentScreenPaddings.calculateBottomPadding(),
+        bottom = contentScreenPaddings.calculateBottomPadding()
+    )
+}
 
 private fun calculateTopSpacing(topSpacing: TopSpacing): Int = when (topSpacing) {
     TopSpacing.WithToolbar -> SPACING_SMALL

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/wrap/WrapBottomBarButton.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/wrap/WrapBottomBarButton.kt
@@ -18,10 +18,7 @@ package eu.europa.ec.eudi.rqesui.presentation.ui.component.wrap
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
@@ -30,7 +27,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import eu.europa.ec.eudi.rqesui.infrastructure.theme.values.divider
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.preview.PreviewTheme
@@ -44,32 +40,32 @@ private sealed interface StickyBottomBarConfig {
 
 @Composable
 internal fun WrapBottomBarPrimaryButton(
+    stickyBottomContentModifier: Modifier = Modifier,
     buttonText: String,
     enabled: Boolean = true,
-    padding: PaddingValues,
     onButtonClick: () -> Unit,
 ) {
     WrapStickyBottomBar(
         config = StickyBottomBarConfig.Primary,
+        stickyBottomContentModifier = stickyBottomContentModifier,
         buttonText = buttonText,
         enabled = enabled,
-        padding = padding,
         onButtonClick = onButtonClick,
     )
 }
 
 @Composable
 internal fun WrapBottomBarSecondaryButton(
+    stickyBottomContentModifier: Modifier = Modifier,
     buttonText: String,
     enabled: Boolean = true,
-    padding: PaddingValues,
     onButtonClick: () -> Unit,
 ) {
     WrapStickyBottomBar(
         config = StickyBottomBarConfig.Secondary,
+        stickyBottomContentModifier = stickyBottomContentModifier,
         buttonText = buttonText,
         enabled = enabled,
-        padding = padding,
         onButtonClick = onButtonClick,
     )
 }
@@ -77,9 +73,9 @@ internal fun WrapBottomBarSecondaryButton(
 @Composable
 private fun WrapStickyBottomBar(
     config: StickyBottomBarConfig,
+    stickyBottomContentModifier: Modifier = Modifier,
     buttonText: String,
     enabled: Boolean,
-    padding: PaddingValues,
     onButtonClick: () -> Unit,
 ) {
     Column(
@@ -93,14 +89,7 @@ private fun WrapStickyBottomBar(
         )
 
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    top = padding.calculateBottomPadding(),
-                    bottom = padding.calculateBottomPadding(),
-                    start = padding.calculateStartPadding(LayoutDirection.Ltr),
-                    end = padding.calculateEndPadding(LayoutDirection.Ltr)
-                ),
+            modifier = stickyBottomContentModifier,
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center
         ) {
@@ -156,8 +145,10 @@ private fun ConfigBasedButton(
 private fun WrapBottomBarPrimaryButtonPreview() {
     PreviewTheme {
         WrapBottomBarPrimaryButton(
+            stickyBottomContentModifier = Modifier
+                .fillMaxWidth()
+                .padding(SPACING_LARGE.dp),
             buttonText = "Sign",
-            padding = PaddingValues(SPACING_LARGE.dp),
             onButtonClick = {},
         )
     }
@@ -168,8 +159,10 @@ private fun WrapBottomBarPrimaryButtonPreview() {
 private fun WrapBottomBarSecondaryButtonPreview() {
     PreviewTheme {
         WrapBottomBarSecondaryButton(
+            stickyBottomContentModifier = Modifier
+                .fillMaxWidth()
+                .padding(SPACING_LARGE.dp),
             buttonText = "Sign",
-            padding = PaddingValues(SPACING_LARGE.dp),
             onButtonClick = {},
         )
     }

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/select_certificate/SelectCertificateScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/select_certificate/SelectCertificateScreen.kt
@@ -105,9 +105,11 @@ internal fun SelectCertificateScreen(
         contentErrorConfig = state.error,
         stickyBottom = { paddingValues ->
             WrapBottomBarPrimaryButton(
+                stickyBottomContentModifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues),
                 buttonText = state.bottomBarButtonText,
                 enabled = state.isBottomBarButtonEnabled,
-                padding = paddingValues,
                 onButtonClick = {
                     viewModel.setEvent(
                         Event.BottomBarButtonPressed

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/select_qtsp/SelectQtspScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/select_qtsp/SelectQtspScreen.kt
@@ -79,8 +79,10 @@ internal fun SelectQtspScreen(
         contentErrorConfig = state.error,
         stickyBottom = { paddingValues ->
             WrapBottomBarPrimaryButton(
+                stickyBottomContentModifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues),
                 buttonText = state.bottomBarButtonText,
-                padding = paddingValues,
                 onButtonClick = {
                     viewModel.setEvent(
                         Event.BottomBarButtonPressed

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/success/SuccessScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/success/SuccessScreen.kt
@@ -83,9 +83,11 @@ internal fun SuccessScreen(
         contentErrorConfig = state.error,
         stickyBottom = { paddingValues ->
             WrapBottomBarSecondaryButton(
+                stickyBottomContentModifier = Modifier
+                    .fillMaxWidth()
+                    .padding(paddingValues),
                 buttonText = state.bottomBarButtonText,
                 enabled = state.isBottomBarButtonEnabled,
-                padding = paddingValues,
                 onButtonClick = {
                     viewModel.setEvent(
                         Event.BottomBarButtonPressed


### PR DESCRIPTION
# Description of changes
- Refactor bottom bar buttons to receive a modifier for padding instead of PaddingValues.
- Update usages of bottom bar buttons in SuccessScreen, SelectCertificateScreen, and SelectQtspScreen to pass padding via modifier.
- Update ContentScreen to calculate paddings for sticky bottom content based on screen padding and layout direction.
- Update ScreenPadding.kt with a new function to calculate sticky bottom paddings.

## Type of change

Please delete options that are not relevant.

- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable