### PR TITLE
Refactor: Renamed previews in ContentError.kt

### DIFF
--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
@@ -104,6 +104,7 @@ private fun ErrorTitle(
             text = title,
             style = titleStyle,
         )
+
         VSpacer.Large()
 
         subtitle?.let { safeSubtitle ->
@@ -120,7 +121,7 @@ private fun ErrorTitle(
 
 @ThemeModePreviews
 @Composable
-private fun ErrorTitlePreview() {
+private fun PreviewErrorTitlePreview() {
     PreviewTheme {
         ErrorTitle(
             modifier = Modifier.fillMaxWidth(),
@@ -132,7 +133,7 @@ private fun ErrorTitlePreview() {
 
 @ThemeModePreviews
 @Composable
-private fun ContentTitleNoSubtitlePreview() {
+private fun PreviewErrorTitleNoSubtitlePreview() {
     PreviewTheme {
         ErrorTitle(
             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
# Description of changes
- Renamed `ErrorTitlePreview` to `PreviewErrorTitlePreview`.
- Renamed `ContentTitleNoSubtitlePreview` to `PreviewErrorTitleNoSubtitlePreview`.
- Added extra space between title and subtitle in `ErrorTitle` composable.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable