### PR TITLE
Refactor: Improve content error handling and presentation

### DIFF
--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/controller/LocalizationController.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/controller/LocalizationController.kt
@@ -53,7 +53,10 @@ internal class LocalizationControllerImpl(
         args: List<String>,
     ): String {
         if (config.translations.isEmpty()) {
-            throw EudiRQESUiError(message = "No translations found. Please provide translations in the config.")
+            throw EudiRQESUiError(
+                title = "Translation Error",
+                message = "No translations found. Please provide translations in the config."
+            )
         }
 
         val language = Locale.getDefault().language

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/controller/RqesController.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/controller/RqesController.kt
@@ -85,6 +85,9 @@ internal class RqesControllerImpl(
     private val genericErrorMsg
         get() = resourceProvider.genericErrorMessage()
 
+    private val genericErrorTitle
+        get() = resourceProvider.genericErrorTitle()
+
     private val genericServiceErrorMsg
         get() = resourceProvider.genericServiceErrorMessage()
 
@@ -95,12 +98,14 @@ internal class RqesControllerImpl(
                 EudiRqesGetSelectedFilePartialState.Success(file = safeSelectedFile)
             } ?: EudiRqesGetSelectedFilePartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = resourceProvider.getLocalizedString(LocalizableKey.GenericErrorDocumentNotFound)
                 )
             )
         }.getOrElse {
             EudiRqesGetSelectedFilePartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )
@@ -113,6 +118,7 @@ internal class RqesControllerImpl(
         }.getOrElse {
             EudiRqesGetQtspsPartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )
@@ -140,6 +146,7 @@ internal class RqesControllerImpl(
         }.getOrElse {
             EudiRqesSetSelectedQtspPartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )
@@ -153,12 +160,14 @@ internal class RqesControllerImpl(
                 EudiRqesGetSelectedQtspPartialState.Success(qtsp = safeSelectedQtsp)
             } ?: EudiRqesGetSelectedQtspPartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = resourceProvider.getLocalizedString(LocalizableKey.GenericErrorQtspNotFound)
                 )
             )
         }.getOrElse {
             EudiRqesGetSelectedQtspPartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )
@@ -175,6 +184,7 @@ internal class RqesControllerImpl(
             }.getOrElse {
                 EudiRqesGetServiceAuthorizationUrlPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericServiceErrorMsg
                     )
                 )
@@ -196,12 +206,14 @@ internal class RqesControllerImpl(
                     EudiRqesAuthorizeServicePartialState.Success(authorizedService = authorizedService)
                 } ?: EudiRqesAuthorizeServicePartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericErrorMsg
                     )
                 )
             }.getOrElse {
                 EudiRqesAuthorizeServicePartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericServiceErrorMsg
                     )
                 )
@@ -235,6 +247,7 @@ internal class RqesControllerImpl(
                 } else {
                     EudiRqesGetCertificatesPartialState.Failure(
                         error = EudiRQESUiError(
+                            title = genericErrorTitle,
                             message = resourceProvider.getLocalizedString(LocalizableKey.GenericErrorCertificatesNotFound)
                         )
                     )
@@ -242,6 +255,7 @@ internal class RqesControllerImpl(
             }.getOrElse {
                 EudiRqesGetCertificatesPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericServiceErrorMsg
                     )
                 )
@@ -281,6 +295,7 @@ internal class RqesControllerImpl(
                     EudiRqesGetCredentialAuthorizationUrlPartialState.Success(authorizationUrl = authorizationUrl)
                 } ?: EudiRqesGetCredentialAuthorizationUrlPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = resourceProvider.getLocalizedString(
                             LocalizableKey.GenericErrorDocumentNotFound
                         )
@@ -289,6 +304,7 @@ internal class RqesControllerImpl(
             }.getOrElse {
                 EudiRqesGetCredentialAuthorizationUrlPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericServiceErrorMsg
                     )
                 )
@@ -311,12 +327,14 @@ internal class RqesControllerImpl(
                     EudiRqesAuthorizeCredentialPartialState.Success(authorizedCredential = authorizedCredential)
                 } ?: EudiRqesAuthorizeCredentialPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericErrorMsg
                     )
                 )
             }.getOrElse {
                 EudiRqesAuthorizeCredentialPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericServiceErrorMsg
                     )
                 )
@@ -332,6 +350,7 @@ internal class RqesControllerImpl(
             }.getOrElse {
                 EudiRqesSignDocumentsPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = genericServiceErrorMsg
                     )
                 )
@@ -361,12 +380,16 @@ internal class RqesControllerImpl(
                     EudiRqesSaveSignedDocumentsPartialState.Success(savedDocumentsUri = uris)
                 } else {
                     EudiRqesSaveSignedDocumentsPartialState.Failure(
-                        error = EudiRQESUiError(message = genericErrorMsg)
+                        error = EudiRQESUiError(
+                            title = genericErrorTitle,
+                            message = genericErrorMsg
+                        )
                     )
                 }
             }.getOrElse {
                 EudiRqesSaveSignedDocumentsPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = it.localizedMessage ?: genericErrorMsg
                     )
                 )
@@ -397,6 +420,7 @@ internal class RqesControllerImpl(
         }.getOrElse {
             EudiRqesCreateServicePartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/entities/error/EudiRQESUiError.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/entities/error/EudiRQESUiError.kt
@@ -17,6 +17,7 @@
 package eu.europa.ec.eudi.rqesui.domain.entities.error
 
 class EudiRQESUiError(
+    val title: String,
     override val message: String,
     override val cause: Throwable? = null
 ) : Exception(message, cause)

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/extension/UriExtensions.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/extension/UriExtensions.kt
@@ -39,7 +39,12 @@ internal fun Uri.getFileName(context: Context): Result<String> {
         cursor.getString(nameIndex)
     }
     return if (fileName.isNullOrEmpty()) {
-        Result.failure(EudiRQESUiError(message = "Unable to determine file name"))
+        Result.failure(
+            EudiRQESUiError(
+                title = "File Error",
+                message = "Unable to determine file name"
+            )
+        )
     } else {
         Result.success(fileName)
     }

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/interactor/OptionsSelectionInteractor.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/interactor/OptionsSelectionInteractor.kt
@@ -79,6 +79,9 @@ internal class OptionsSelectionInteractorImpl(
     private val genericErrorMsg
         get() = resourceProvider.genericErrorMessage()
 
+    private val genericErrorTitle
+        get() = resourceProvider.genericErrorTitle()
+
     override fun getQtsps(): EudiRqesGetQtspsPartialState {
         return eudiRqesController.getQtsps()
     }
@@ -128,6 +131,7 @@ internal class OptionsSelectionInteractorImpl(
             }.getOrElse {
                 OptionsSelectionInteractorAuthorizeServiceAndFetchCertificatesPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = it.localizedMessage ?: genericErrorMsg
                     )
                 )
@@ -159,11 +163,15 @@ internal class OptionsSelectionInteractorImpl(
                         }
                     }
                 } ?: return@runCatching EudiRqesGetCredentialAuthorizationUrlPartialState.Failure(
-                    error = EudiRQESUiError(message = genericErrorMsg)
+                    error = EudiRQESUiError(
+                        title = genericErrorTitle,
+                        message = genericErrorMsg
+                    )
                 )
             }.getOrElse {
                 EudiRqesGetCredentialAuthorizationUrlPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = it.localizedMessage ?: genericErrorMsg
                     )
                 )
@@ -189,6 +197,7 @@ internal class OptionsSelectionInteractorImpl(
         }.getOrElse {
             OptionsSelectionInteractorGetSelectedQtspPartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/interactor/SuccessInteractor.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/interactor/SuccessInteractor.kt
@@ -44,6 +44,9 @@ internal class SuccessInteractorImpl(
     private val genericErrorMsg
         get() = resourceProvider.genericErrorMessage()
 
+    private val genericErrorTitle
+        get() = resourceProvider.genericErrorTitle()
+
     override fun getSelectedFileAndQtsp(): SuccessInteractorGetSelectedFileAndQtspPartialState {
         return runCatching {
             when (val getSelectedFileResponse = eudiRqesController.getSelectedFile()) {
@@ -73,6 +76,7 @@ internal class SuccessInteractorImpl(
         }.getOrElse {
             SuccessInteractorGetSelectedFileAndQtspPartialState.Failure(
                 error = EudiRQESUiError(
+                    title = genericErrorTitle,
                     message = it.localizedMessage ?: genericErrorMsg
                 )
             )
@@ -140,6 +144,7 @@ internal class SuccessInteractorImpl(
             }.getOrElse {
                 SuccessInteractorSignAndSaveDocumentPartialState.Failure(
                     error = EudiRQESUiError(
+                        title = genericErrorTitle,
                         message = it.localizedMessage ?: genericErrorMsg
                     )
                 )

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/EudiRQESUi.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/EudiRQESUi.kt
@@ -40,6 +40,9 @@ import org.koin.ksp.generated.module
 
 object EudiRQESUi {
 
+    private const val SDK_NOT_INITIALIZED_TITLE =
+        "EudiRQESUi Error"
+
     private const val SDK_NOT_INITIALIZED_MESSAGE =
         "Before calling resume, SDK must be initialized firstly. Call EudiRQESUi.launchSDK()"
 
@@ -124,6 +127,7 @@ object EudiRQESUi {
     ) {
         if (!::sessionData.isInitialized) {
             throw EudiRQESUiError(
+                title = SDK_NOT_INITIALIZED_TITLE,
                 message = SDK_NOT_INITIALIZED_MESSAGE
             )
         }
@@ -146,7 +150,10 @@ object EudiRQESUi {
     @Throws(EudiRQESUiError::class)
     internal fun getEudiRQESUiConfig(): EudiRQESUiConfig {
         if (!::_eudiRQESUiConfig.isInitialized) {
-            throw EudiRQESUiError(message = SDK_NOT_INITIALIZED_MESSAGE)
+            throw EudiRQESUiError(
+                title = SDK_NOT_INITIALIZED_TITLE,
+                message = SDK_NOT_INITIALIZED_MESSAGE
+            )
         }
         return _eudiRQESUiConfig
     }
@@ -195,7 +202,10 @@ object EudiRQESUi {
                 )
             )
         } else {
-            throw EudiRQESUiError(message = "Context passed is not an Activity.")
+            throw EudiRQESUiError(
+                title = "Context Error",
+                message = "Context passed is not an Activity."
+            )
         }
     }
 
@@ -230,7 +240,10 @@ object EudiRQESUi {
                     State.Success
                 }
             }
-        } ?: throw EudiRQESUiError(message = SDK_NOT_INITIALIZED_MESSAGE)
+        } ?: throw EudiRQESUiError(
+            title = SDK_NOT_INITIALIZED_TITLE,
+            message = SDK_NOT_INITIALIZED_MESSAGE
+        )
     }
 
     private fun setState(state: State) {

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/provider/ResourceProvider.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/provider/ResourceProvider.kt
@@ -31,6 +31,7 @@ internal interface ResourceProvider {
     fun getStringFromRaw(@RawRes resId: Int): String
     fun getQuantityString(@PluralsRes resId: Int, quantity: Int, vararg formatArgs: Any): String
     fun getString(@StringRes resId: Int, vararg formatArgs: Any): String
+    fun genericErrorTitle(): String
     fun genericErrorMessage(): String
     fun genericServiceErrorMessage(): String
     fun getLocalizedString(localizableKey: LocalizableKey, args: List<String> = emptyList()): String
@@ -44,6 +45,9 @@ internal class ResourceProviderImpl(
     override fun provideContext() = context
 
     override fun provideContentResolver(): ContentResolver = context.contentResolver
+
+    override fun genericErrorTitle(): String =
+        getLocalizedString(LocalizableKey.GenericErrorMessage)
 
     override fun genericErrorMessage() = getLocalizedString(LocalizableKey.GenericErrorDescription)
 

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
@@ -38,7 +38,7 @@ import eu.europa.ec.eudi.rqesui.presentation.ui.component.wrap.WrapPrimaryButton
 import org.koin.compose.koinInject
 
 internal data class ContentErrorConfig(
-    val errorTitle: String? = null,
+    val errorTitle: String,
     val errorSubTitle: String? = null,
     val onCancel: () -> Unit,
     val onRetry: (() -> Unit)? = null
@@ -98,7 +98,10 @@ internal fun ContentError(
 private fun PreviewContentErrorScreen() {
     PreviewTheme {
         ContentError(
-            config = ContentErrorConfig(onCancel = {}),
+            config = ContentErrorConfig(
+                errorTitle = "Error Title",
+                onCancel = {}
+            ),
             paddingValues = PaddingValues(SIZE_MEDIUM.dp)
         )
     }

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
@@ -39,7 +39,7 @@ import org.koin.compose.koinInject
 
 internal data class ContentErrorConfig(
     val errorTitle: String,
-    val errorSubTitle: String? = null,
+    val errorSubTitle: String,
     val onCancel: () -> Unit,
     val onRetry: (() -> Unit)? = null
 )
@@ -55,10 +55,6 @@ internal fun ContentError(
     subTitleMaxLines: Int = Int.MAX_VALUE
 ) {
 
-    val subtitle = config.errorSubTitle ?: resourceProvider.getLocalizedString(
-        LocalizableKey.GenericErrorDescription
-    )
-
     Column(
         Modifier
             .fillMaxSize()
@@ -67,7 +63,7 @@ internal fun ContentError(
 
         Text(
             modifier = Modifier.fillMaxWidth(),
-            text = subtitle,
+            text = config.errorSubTitle,
             style = subtitleStyle,
             maxLines = subTitleMaxLines,
             overflow = TextOverflow.Ellipsis
@@ -100,6 +96,7 @@ private fun PreviewContentErrorScreen() {
         ContentError(
             config = ContentErrorConfig(
                 errorTitle = "Error Title",
+                errorSubTitle = "Error Message",
                 onCancel = {}
             ),
             paddingValues = PaddingValues(SIZE_MEDIUM.dp)

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentError.kt
@@ -16,7 +16,6 @@
 
 package eu.europa.ec.eudi.rqesui.presentation.ui.component.content
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -35,7 +34,6 @@ import eu.europa.ec.eudi.rqesui.infrastructure.provider.ResourceProvider
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.preview.PreviewTheme
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.preview.ThemeModePreviews
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.SIZE_MEDIUM
-import eu.europa.ec.eudi.rqesui.presentation.ui.component.utils.VSpacer
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.wrap.WrapPrimaryButton
 import org.koin.compose.koinInject
 
@@ -51,18 +49,28 @@ internal fun ContentError(
     config: ContentErrorConfig,
     paddingValues: PaddingValues,
     resourceProvider: ResourceProvider = koinInject(),
+    subtitleStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(
+        color = MaterialTheme.colorScheme.onSurface
+    ),
+    subTitleMaxLines: Int = Int.MAX_VALUE
 ) {
+
+    val subtitle = config.errorSubTitle ?: resourceProvider.getLocalizedString(
+        LocalizableKey.GenericErrorDescription
+    )
+
     Column(
         Modifier
             .fillMaxSize()
-            .padding(paddingValues),
+            .padding(paddingValues)
     ) {
-        ErrorTitle(
-            title = config.errorTitle
-                ?: resourceProvider.getLocalizedString(LocalizableKey.GenericErrorMessage),
-            subtitle = config.errorSubTitle
-                ?: resourceProvider.getLocalizedString(LocalizableKey.GenericErrorDescription),
-            subTitleMaxLines = 10
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = subtitle,
+            style = subtitleStyle,
+            maxLines = subTitleMaxLines,
+            overflow = TextOverflow.Ellipsis
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -79,67 +87,6 @@ internal fun ContentError(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun ErrorTitle(
-    modifier: Modifier = Modifier,
-    title: String,
-    subtitle: String? = null,
-    titleStyle: TextStyle = MaterialTheme.typography.headlineSmall.copy(
-        color = MaterialTheme.colorScheme.onSurface
-    ),
-    subtitleStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(
-        color = MaterialTheme.colorScheme.onSurface
-    ),
-    subTitleMaxLines: Int = Int.MAX_VALUE,
-) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.Top
-    ) {
-        Text(
-            modifier = Modifier.fillMaxWidth(),
-            text = title,
-            style = titleStyle,
-        )
-
-        VSpacer.Large()
-
-        subtitle?.let { safeSubtitle ->
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = safeSubtitle,
-                style = subtitleStyle,
-                maxLines = subTitleMaxLines,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-    }
-}
-
-@ThemeModePreviews
-@Composable
-private fun PreviewErrorTitle() {
-    PreviewTheme {
-        ErrorTitle(
-            modifier = Modifier.fillMaxWidth(),
-            title = "Title",
-            subtitle = "Subtitle"
-        )
-    }
-}
-
-@ThemeModePreviews
-@Composable
-private fun PreviewErrorTitleNoSubtitle() {
-    PreviewTheme {
-        ErrorTitle(
-            modifier = Modifier.fillMaxWidth(),
-            title = "Title",
-            subtitle = null
-        )
     }
 }
 

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
@@ -148,6 +148,7 @@ internal fun ContentScreen(
                     onBack = contentErrorConfig?.onCancel ?: onBack,
                     keyboardController = keyboardController,
                     toolbarConfig = toolBarConfig,
+                    contentErrorConfig = contentErrorConfig
                 )
             }
         },
@@ -212,8 +213,11 @@ private fun DefaultToolBar(
     onBack: (() -> Unit)?,
     keyboardController: SoftwareKeyboardController?,
     toolbarConfig: ToolbarConfig?,
+    contentErrorConfig: ContentErrorConfig?
 ) {
-    val isTitlePresent = !toolbarConfig?.title.isNullOrEmpty()
+
+    val title = contentErrorConfig?.errorTitle ?: toolbarConfig?.title
+    val isTitlePresent = !title.isNullOrEmpty()
 
     val modifier = Modifier
         .fillMaxWidth()
@@ -235,7 +239,7 @@ private fun DefaultToolBar(
         title = {
             if (isTitlePresent) {
                 Text(
-                    text = toolbarConfig.title,
+                    text = title,
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/container/EudiRQESContainer.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/container/EudiRQESContainer.kt
@@ -99,7 +99,10 @@ internal class EudiRQESContainer : ComponentActivity() {
      */
     private fun buildScreenAndArgumentsFromState(state: EudiRQESUi.State?): Pair<Screen, String> {
         return when (state) {
-            is EudiRQESUi.State.None, null -> throw EudiRQESUiError(message = "EUDIRQESUI-SDK: Missing state")
+            is EudiRQESUi.State.None, null -> throw EudiRQESUiError(
+                title = "State Error",
+                message = "EUDIRQESUI-SDK: Missing state"
+            )
 
             is EudiRQESUi.State.Initial -> SdkScreens.OptionsSelection to prepareOptionsSelectionScreenArguments(
                 OptionsSelectionScreenState.QtspSelection

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/OptionsSelectionViewModel.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/OptionsSelectionViewModel.kt
@@ -236,6 +236,7 @@ internal class OptionsSelectionViewModel(
                         setState {
                             copy(
                                 error = ContentErrorConfig(
+                                    errorTitle = response.error.title,
                                     onRetry = {
                                         setEvent(Event.DismissError)
                                         setEvent(event)
@@ -332,6 +333,7 @@ internal class OptionsSelectionViewModel(
                 setState {
                     copy(
                         error = ContentErrorConfig(
+                            errorTitle = response.error.title,
                             onRetry = { setEvent(event) },
                             errorSubTitle = response.error.message,
                             onCancel = {
@@ -371,6 +373,7 @@ internal class OptionsSelectionViewModel(
                 setState {
                     copy(
                         error = ContentErrorConfig(
+                            errorTitle = response.error.title,
                             onRetry = { setEvent(event) },
                             errorSubTitle = response.error.message,
                             onCancel = {
@@ -407,6 +410,7 @@ internal class OptionsSelectionViewModel(
                 setState {
                     copy(
                         error = ContentErrorConfig(
+                            errorTitle = response.error.title,
                             onRetry = { setEvent(event) },
                             errorSubTitle = response.error.message,
                             onCancel = {
@@ -485,6 +489,7 @@ internal class OptionsSelectionViewModel(
                 setState {
                     copy(
                         error = ContentErrorConfig(
+                            errorTitle = response.error.title,
                             onRetry = { setEvent(event) },
                             errorSubTitle = response.error.message,
                             onCancel = {
@@ -532,6 +537,7 @@ internal class OptionsSelectionViewModel(
                     setState {
                         copy(
                             error = ContentErrorConfig(
+                                errorTitle = response.error.title,
                                 onRetry = {
                                     setEvent(Event.DismissError)
                                     setEvent(event)
@@ -568,6 +574,7 @@ internal class OptionsSelectionViewModel(
                         copy(
                             certificateDataList = emptyList(),
                             error = ContentErrorConfig(
+                                errorTitle = response.error.title,
                                 onRetry = {
                                     setEvent(Event.DismissError)
                                     setEvent(event)
@@ -610,6 +617,7 @@ internal class OptionsSelectionViewModel(
                     setState {
                         copy(
                             error = ContentErrorConfig(
+                                errorTitle = response.error.title,
                                 onRetry = {
                                     setEvent(Event.DismissError)
                                     setEvent(event)

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/success/SuccessViewModel.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/success/SuccessViewModel.kt
@@ -192,6 +192,7 @@ internal class SuccessViewModel(
                 setState {
                     copy(
                         error = ContentErrorConfig(
+                            errorTitle = getSelectFileAndQtspResponse.error.title,
                             onRetry = {
                                 setEvent(Event.DismissError)
                                 setEvent(event)
@@ -231,6 +232,7 @@ internal class SuccessViewModel(
                     setState {
                         copy(
                             error = ContentErrorConfig(
+                                errorTitle = response.error.title,
                                 onRetry = {
                                     setEvent(Event.DismissError)
                                     setEvent(event)

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/view_document/ViewDocumentViewModel.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/view_document/ViewDocumentViewModel.kt
@@ -29,7 +29,6 @@ import org.koin.core.annotation.InjectedParam
 
 internal data class State(
     val config: ViewDocumentUiConfig,
-
     val isLoading: Boolean = false,
     val buttonText: String,
 ) : ViewState
@@ -37,7 +36,6 @@ internal data class State(
 internal sealed class Event : ViewEvent {
     data object Pop : Event()
     data object BottomBarButtonPressed : Event()
-
     data class LoadingStateChanged(val isLoading: Boolean) : Event()
 }
 

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/controller/TestRqesController.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/controller/TestRqesController.kt
@@ -43,6 +43,7 @@ import eu.europa.ec.eudi.rqesui.util.mockedDocumentNotFoundMessage
 import eu.europa.ec.eudi.rqesui.util.mockedExceptionWithMessage
 import eu.europa.ec.eudi.rqesui.util.mockedExceptionWithNoMessage
 import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorMessage
+import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorTitle
 import eu.europa.ec.eudi.rqesui.util.mockedGenericServiceErrorMessage
 import eu.europa.ec.eudi.rqesui.util.mockedQtspEndpoint
 import eu.europa.ec.eudi.rqesui.util.mockedQtspName
@@ -128,6 +129,8 @@ class TestRqesController {
             .thenReturn(mockedGenericErrorMessage)
         whenever(resourceProvider.genericServiceErrorMessage())
             .thenReturn(mockedGenericServiceErrorMessage)
+        whenever(resourceProvider.genericErrorTitle())
+            .thenReturn(mockedGenericErrorTitle)
     }
 
     @After
@@ -261,7 +264,8 @@ class TestRqesController {
         val result = rqesController.getQtsps()
 
         // Assert
-        val expectedError = EudiRQESUiError(message = mockedGenericErrorMessage)
+        val expectedError =
+            EudiRQESUiError(title = mockedGenericErrorTitle, message = mockedGenericErrorMessage)
         assertEquals(
             expectedError.message,
             (result as EudiRqesGetQtspsPartialState.Failure).error.message,

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/interactor/TestOptionsSelectionInteractor.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/interactor/TestOptionsSelectionInteractor.kt
@@ -33,6 +33,7 @@ import eu.europa.ec.eudi.rqesui.util.CoroutineTestRule
 import eu.europa.ec.eudi.rqesui.util.mockedAuthorizationUrl
 import eu.europa.ec.eudi.rqesui.util.mockedExceptionWithMessage
 import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorMessage
+import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorTitle
 import eu.europa.ec.eudi.rqesui.util.mockedPlainFailureMessage
 import eu.europa.ec.eudi.rqesui.util.runTest
 import junit.framework.TestCase.assertEquals
@@ -90,6 +91,8 @@ class TestOptionsSelectionInteractor {
         )
         whenever(resourceProvider.genericErrorMessage())
             .thenReturn(mockedGenericErrorMessage)
+        whenever(resourceProvider.genericErrorTitle())
+            .thenReturn(mockedGenericErrorTitle)
     }
 
     @After
@@ -175,7 +178,10 @@ class TestOptionsSelectionInteractor {
     fun `Given that service authorization fails, When authorizeServiceAndFetchCertificates is called, Then return Failure`() =
         coroutineRule.runTest {
             // Arrange
-            val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+            val error = EudiRQESUiError(
+                title = mockedGenericErrorTitle,
+                message = mockedPlainFailureMessage
+            )
             mockAuthorizeServiceCall(
                 EudiRqesAuthorizeServicePartialState.Failure(error)
             )
@@ -213,7 +219,10 @@ class TestOptionsSelectionInteractor {
     fun `Given service authorization succeeds but certificate fetch fails, When authorizeServiceAndFetchCertificates is called, Then return Failure`() =
         coroutineRule.runTest {
             // Arrange
-            val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+            val error = EudiRQESUiError(
+                title = mockedGenericErrorTitle,
+                message = mockedPlainFailureMessage
+            )
             mockAuthorizeServiceCall(
                 EudiRqesAuthorizeServicePartialState.Success(authorizedService = rqesServiceAuthorized)
             )
@@ -255,7 +264,8 @@ class TestOptionsSelectionInteractor {
     @Test
     fun `Given selected file retrieval fails, When getSelectedFileAndQtsp is called, Then return Failure`() {
         // Arrange
-        val error = EudiRQESUiError(message = mockedGenericErrorMessage)
+        val error =
+            EudiRQESUiError(title = mockedGenericErrorTitle, message = mockedGenericErrorMessage)
         whenever(eudiController.getSelectedFile())
             .thenReturn(EudiRqesGetSelectedFilePartialState.Failure(error))
 
@@ -275,7 +285,8 @@ class TestOptionsSelectionInteractor {
         // Arrange
         whenever(eudiController.getSelectedFile())
             .thenReturn(EudiRqesGetSelectedFilePartialState.Success(file = documentData))
-        val failureError = EudiRQESUiError(message = mockedPlainFailureMessage)
+        val failureError =
+            EudiRQESUiError(title = mockedGenericErrorTitle, message = mockedPlainFailureMessage)
         whenever(eudiController.getSelectedQtsp())
             .thenReturn(EudiRqesGetSelectedQtspPartialState.Failure(error = failureError))
 
@@ -333,7 +344,10 @@ class TestOptionsSelectionInteractor {
     fun `Given getCredentialAuthorizationUrl returns Failure, When getCredentialAuthorizationUrl is called, Then Failure state is returned`() =
         coroutineRule.runTest {
             // Arrange
-            val expectedError = EudiRQESUiError(message = mockedPlainFailureMessage)
+            val expectedError = EudiRQESUiError(
+                title = mockedGenericErrorTitle,
+                message = mockedPlainFailureMessage
+            )
             val failureResponse = EudiRqesGetCredentialAuthorizationUrlPartialState.Failure(
                 error = expectedError
             )

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/interactor/TestSuccessInteractor.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/interactor/TestSuccessInteractor.kt
@@ -38,6 +38,7 @@ import eu.europa.ec.eudi.rqesui.util.mockedDocumentName
 import eu.europa.ec.eudi.rqesui.util.mockedExceptionWithMessage
 import eu.europa.ec.eudi.rqesui.util.mockedExceptionWithNoMessage
 import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorMessage
+import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorTitle
 import eu.europa.ec.eudi.rqesui.util.mockedPlainFailureMessage
 import eu.europa.ec.eudi.rqesui.util.runTest
 import junit.framework.TestCase.assertEquals
@@ -100,6 +101,8 @@ class TestSuccessInteractor {
         whenever(resourceProvider.genericErrorMessage())
             .thenReturn(mockedGenericErrorMessage)
         whenever(resourceProvider.provideContext()).thenReturn(context)
+        whenever(resourceProvider.genericErrorTitle())
+            .thenReturn(mockedGenericErrorTitle)
     }
 
     @After
@@ -138,7 +141,8 @@ class TestSuccessInteractor {
     @Test
     fun `Given Case 2, When getSelectedFileAndQtsp is called, Then Case 2 expected result is returned`() {
         // Arrange
-        val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+        val error =
+            EudiRQESUiError(title = mockedGenericErrorTitle, message = mockedPlainFailureMessage)
         mockGetSelectedFileCall(event = EudiRqesGetSelectedFilePartialState.Failure(error = error))
 
         // Act
@@ -162,7 +166,8 @@ class TestSuccessInteractor {
     @Test
     fun `Given Case 3, When getSelectedFileAndQtsp is called, Then Case 3 expected result is returned`() {
         // Arrange
-        val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+        val error =
+            EudiRQESUiError(title = mockedGenericErrorTitle, message = mockedPlainFailureMessage)
         mockGetSelectedFileCall(event = EudiRqesGetSelectedFilePartialState.Success(file = documentData))
         mockGetSelectedQtspCall(event = EudiRqesGetSelectedQtspPartialState.Failure(error = error))
 
@@ -270,7 +275,10 @@ class TestSuccessInteractor {
     fun `Given Case 2, When signAndSaveDocument is called, Then Case 2 expected result is returned`() =
         coroutineRule.runTest {
             // Arrange
-            val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+            val error = EudiRQESUiError(
+                title = mockedGenericErrorTitle,
+                message = mockedPlainFailureMessage
+            )
             mockAuthorizeCredentialCall(
                 response = EudiRqesAuthorizeCredentialPartialState.Failure(
                     error = error
@@ -299,7 +307,10 @@ class TestSuccessInteractor {
     fun `Given Case 3, When signAndSaveDocument is called, Then Case 3 expected result is returned`() =
         coroutineRule.runTest {
             // Arrange
-            val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+            val error = EudiRQESUiError(
+                title = mockedGenericErrorTitle,
+                message = mockedPlainFailureMessage
+            )
             mockAuthorizeCredentialCall(
                 response = EudiRqesAuthorizeCredentialPartialState.Success(
                     credentialAuthorized
@@ -331,7 +342,10 @@ class TestSuccessInteractor {
     fun `Given Case 4, When signAndSaveDocument is called, Then Case 4 expected result is returned`() =
         coroutineRule.runTest {
             // Arrange
-            val error = EudiRQESUiError(message = mockedPlainFailureMessage)
+            val error = EudiRQESUiError(
+                title = mockedGenericErrorTitle,
+                message = mockedPlainFailureMessage
+            )
             mockAuthorizeCredentialCall(
                 response = EudiRqesAuthorizeCredentialPartialState.Success(
                     authorizedCredential = credentialAuthorized

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/TestOptionsSelectionViewModel.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/TestOptionsSelectionViewModel.kt
@@ -51,6 +51,7 @@ import eu.europa.ec.eudi.rqesui.util.mockedAuthorizationUrl
 import eu.europa.ec.eudi.rqesui.util.mockedCertificateName
 import eu.europa.ec.eudi.rqesui.util.mockedDocumentName
 import eu.europa.ec.eudi.rqesui.util.mockedFetchCertificatesFailureMessage
+import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorTitle
 import eu.europa.ec.eudi.rqesui.util.mockedLocalFileUri
 import eu.europa.ec.eudi.rqesui.util.mockedPlainFailureMessage
 import eu.europa.ec.eudi.rqesui.util.mockedQtspName
@@ -362,7 +363,10 @@ class TestOptionsSelectionViewModel {
             whenever(optionsSelectionInteractor.getSelectedFile())
                 .thenReturn(
                     EudiRqesGetSelectedFilePartialState.Failure(
-                        error = EudiRQESUiError(message = errorMessage)
+                        error = EudiRQESUiError(
+                            title = mockedGenericErrorTitle,
+                            message = errorMessage
+                        )
                     )
                 )
 
@@ -416,7 +420,10 @@ class TestOptionsSelectionViewModel {
             whenever(optionsSelectionInteractor.getSelectedQtsp())
                 .thenReturn(
                     OptionsSelectionInteractorGetSelectedQtspPartialState.Failure(
-                        error = EudiRQESUiError(message = errorMessage)
+                        error = EudiRQESUiError(
+                            title = mockedGenericErrorTitle,
+                            message = errorMessage
+                        )
                     )
                 )
 
@@ -530,7 +537,7 @@ class TestOptionsSelectionViewModel {
             // Arrange
             val errorMessage = mockedPlainFailureMessage
             val failureState = EudiRqesGetQtspsPartialState.Failure(
-                error = EudiRQESUiError(message = errorMessage)
+                error = EudiRQESUiError(title = mockedGenericErrorTitle, message = errorMessage)
             )
             whenever(optionsSelectionInteractor.getQtsps())
                 .thenReturn(failureState)
@@ -785,7 +792,10 @@ class TestOptionsSelectionViewModel {
         coroutineRule.runTest {
             // Arrange
             val failureState = EudiRqesSetSelectedQtspPartialState.Failure(
-                error = EudiRQESUiError(message = mockedPlainFailureMessage)
+                error = EudiRQESUiError(
+                    title = mockedGenericErrorTitle,
+                    message = mockedPlainFailureMessage
+                )
             )
             whenever(optionsSelectionInteractor.updateQtspUserSelection(qtspData)).thenReturn(
                 failureState
@@ -1003,7 +1013,10 @@ class TestOptionsSelectionViewModel {
             whenever(optionsSelectionInteractor.getCredentialAuthorizationUrl(certificateData))
                 .thenReturn(
                     EudiRqesGetCredentialAuthorizationUrlPartialState.Failure(
-                        error = EudiRQESUiError(message = errorMessage)
+                        error = EudiRQESUiError(
+                            title = mockedGenericErrorTitle,
+                            message = errorMessage
+                        )
                     )
                 )
 
@@ -1151,7 +1164,10 @@ class TestOptionsSelectionViewModel {
             // Arrange
             val response =
                 OptionsSelectionInteractorAuthorizeServiceAndFetchCertificatesPartialState.Failure(
-                    EudiRQESUiError(message = mockedFetchCertificatesFailureMessage)
+                    EudiRQESUiError(
+                        title = mockedGenericErrorTitle,
+                        message = mockedFetchCertificatesFailureMessage
+                    )
                 )
             mockAuthorizeServiceAndFetchCertificatesCall(response = response)
 

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/presentation/ui/success/TestSuccessViewModel.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/presentation/ui/success/TestSuccessViewModel.kt
@@ -39,6 +39,7 @@ import eu.europa.ec.eudi.rqesui.presentation.ui.component.content.ContentHeaderC
 import eu.europa.ec.eudi.rqesui.presentation.ui.component.wrap.BottomSheetTextData
 import eu.europa.ec.eudi.rqesui.util.CoroutineTestRule
 import eu.europa.ec.eudi.rqesui.util.mockedDocumentName
+import eu.europa.ec.eudi.rqesui.util.mockedGenericErrorTitle
 import eu.europa.ec.eudi.rqesui.util.mockedLocalFileUri
 import eu.europa.ec.eudi.rqesui.util.mockedPlainFailureMessage
 import eu.europa.ec.eudi.rqesui.util.mockedQtspEndpoint
@@ -246,7 +247,10 @@ class TestSuccessViewModel {
             // Arrange
             val event = Event.SignAndSaveDocument(mockedDocumentName, mockedQtspName)
             val errorResponse = SuccessInteractorSignAndSaveDocumentPartialState.Failure(
-                error = EudiRQESUiError(mockedPlainFailureMessage)
+                error = EudiRQESUiError(
+                    title = mockedGenericErrorTitle,
+                    message = mockedPlainFailureMessage
+                )
             )
             mockSignAndSaveDocumentCall(documentName = mockedDocumentName, response = errorResponse)
 

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/util/Constants.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/util/Constants.kt
@@ -17,6 +17,7 @@
 package eu.europa.ec.eudi.rqesui.util
 
 const val mockedPlainFailureMessage = "Failure message"
+const val mockedGenericErrorTitle = "resourceProvider's genericErrorTitle"
 const val mockedGenericErrorMessage = "resourceProvider's genericErrorMessage"
 const val mockedGenericServiceErrorMessage = "resourceProvider's genericServiceErrorMessage"
 const val mockedAuthorizationUrl = "https://endpoint.com/mockedAuthorizationUrl"


### PR DESCRIPTION
-   Extracted subtitle and title logic to the `ContentError` composable
-   Used optional `contentErrorConfig` for title in the `ContentScreen` composable
-   Removed unnecessary `ErrorTitle` composable
-   Renamed `doAll` to `signAndSaveDocument` in `SuccessViewModel` and `SuccessInteractor`.
-   Updated `SuccessInteractorDoAllPartialState` to `SuccessInteractorSignAndSaveDocumentPartialState`.
-   Updated `Event.DoAll` to `Event.SignAndSaveDocument`.
-   Updated `SuccessScreen` to use the new event name.
-   Removed unnecessary `isLoading` property in the `State` class of `ViewDocumentViewModel`.
-    Removed unused `LoadingStateChanged` class in `Event` of `ViewDocumentViewModel`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable