### PR TITLE
Fix sheet option selections state

### DIFF
--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/wrap/WrapModalBottomSheet.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/wrap/WrapModalBottomSheet.kt
@@ -259,6 +259,7 @@ private fun <T : ViewEvent> OptionsList(
             )
 
             if (index < optionItems.lastIndex) {
+                VSpacer.Small()
                 HorizontalDivider(
                     thickness = 1.dp,
                 )

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/OptionsSelectionViewModel.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/OptionsSelectionViewModel.kt
@@ -264,38 +264,22 @@ internal class OptionsSelectionViewModel(
                 setState {
                     copy(selectedQtspIndex = event.index)
                 }
+                showSelectQtspBottomSheet(event)
             }
 
             is Event.RqesServiceSelectionItemPressed -> {
-                getQtsps(event)
+                showSelectQtspBottomSheet(event)
             }
 
             is Event.CertificateSelectionItemPressed -> {
-                val bottomSheetOptions: List<ModalOptionUi<Event>> =
-                    viewState.value.certificateDataList.mapIndexed { index, certificateData ->
-                        ModalOptionUi(
-                            title = certificateData.name,
-                            trailingIcon = null,
-                            event = Event.BottomSheet.CertificateSelectedOnDoneButtonPressed(
-                                certificateData
-                            ),
-                            radioButtonSelected = index == viewState.value.selectedQtspIndex
-                        )
-                    }
-
-                showBottomSheet(
-                    sheetContent = OptionsSelectionBottomSheetContent.SelectCertificate(
-                        bottomSheetTextData = getSelectCertificateTextData(),
-                        options = bottomSheetOptions,
-                        selectedIndex = 0
-                    )
-                )
+                showSelectCertificateBottomSheet()
             }
 
             is Event.BottomSheet.CertificateIndexSelectedOnRadioButtonPressed -> {
                 setState {
                     copy(selectedCertificateIndex = event.index)
                 }
+                showSelectCertificateBottomSheet()
             }
 
             is Event.BottomSheet.CertificateSelectedOnDoneButtonPressed -> {
@@ -473,7 +457,7 @@ internal class OptionsSelectionViewModel(
         }
     }
 
-    private fun getQtsps(event: Event) {
+    private fun showSelectQtspBottomSheet(event: Event) {
         when (val response = optionsSelectionInteractor.getQtsps()) {
             is EudiRqesGetQtspsPartialState.Failure -> {
                 setState {
@@ -492,13 +476,15 @@ internal class OptionsSelectionViewModel(
             }
 
             is EudiRqesGetQtspsPartialState.Success -> {
+                val currentSelectedQtspIndex = viewState.value.selectedQtspIndex
+
                 val bottomSheetOptions: List<ModalOptionUi<Event>> =
                     response.qtsps.mapIndexed { index, qtspData ->
                         ModalOptionUi(
                             title = qtspData.name,
                             trailingIcon = null,
                             event = Event.BottomSheet.QtspSelectedOnDoneButtonPressed(qtspData),
-                            radioButtonSelected = index == viewState.value.selectedQtspIndex
+                            radioButtonSelected = index == currentSelectedQtspIndex
                         )
                     }
 
@@ -506,11 +492,33 @@ internal class OptionsSelectionViewModel(
                     sheetContent = OptionsSelectionBottomSheetContent.SelectQTSP(
                         bottomSheetTextData = getSelectQTSPTextData(),
                         options = bottomSheetOptions,
-                        selectedIndex = viewState.value.selectedQtspIndex,
+                        selectedIndex = currentSelectedQtspIndex
                     )
                 )
             }
         }
+    }
+
+    private fun showSelectCertificateBottomSheet() {
+        val currentSelectedCertificateIndex = viewState.value.selectedCertificateIndex
+
+        val bottomSheetOptions: List<ModalOptionUi<Event>> =
+            viewState.value.certificateDataList.mapIndexed { index, certificateData ->
+                ModalOptionUi(
+                    title = certificateData.name,
+                    trailingIcon = null,
+                    event = Event.BottomSheet.CertificateSelectedOnDoneButtonPressed(certificateData),
+                    radioButtonSelected = index == currentSelectedCertificateIndex
+                )
+            }
+
+        showBottomSheet(
+            sheetContent = OptionsSelectionBottomSheetContent.SelectCertificate(
+                bottomSheetTextData = getSelectCertificateTextData(),
+                options = bottomSheetOptions,
+                selectedIndex = currentSelectedCertificateIndex
+            )
+        )
     }
 
     private fun fetchServiceAuthorizationUrl(event: Event, service: RQESService) {

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/TestOptionsSelectionViewModel.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/presentation/ui/options_selection/TestOptionsSelectionViewModel.kt
@@ -494,9 +494,9 @@ class TestOptionsSelectionViewModel {
             // Arrange
             val mockQtsps = listOf(qtspData)
             val selectedIndex = 0
-            whenever(qtspData.name).thenReturn(mockedQtspName)
-            whenever(optionsSelectionInteractor.getQtsps())
-                .thenReturn(EudiRqesGetQtspsPartialState.Success(qtsps = mockQtsps))
+            mockGetQtspsCall(
+                response = EudiRqesGetQtspsPartialState.Success(qtsps = mockQtsps)
+            )
 
             // Act
             viewModel.setEvent(
@@ -713,16 +713,20 @@ class TestOptionsSelectionViewModel {
     fun `Given Case 5, When setEvent for Bottom Sheet is called, Then the expected result is returned`() =
         coroutineRule.runTest {
             // Arrange
-            val indexSelected = 0
+            val selectedIndex = 0
+
+            mockGetQtspsCall(
+                response = EudiRqesGetQtspsPartialState.Success(qtsps = listOf(qtspData))
+            )
 
             // Act
             viewModel.setEvent(
-                Event.BottomSheet.QtspIndexSelectedOnRadioButtonPressed(index = indexSelected)
+                Event.BottomSheet.QtspIndexSelectedOnRadioButtonPressed(index = selectedIndex)
             )
 
             // Assert
             assertEquals(
-                indexSelected,
+                selectedIndex,
                 viewModel.viewState.value.selectedQtspIndex
             )
         }
@@ -1314,6 +1318,13 @@ class TestOptionsSelectionViewModel {
                 )
             )
         )
+    }
+
+    private fun mockGetQtspsCall(response: EudiRqesGetQtspsPartialState) {
+        whenever(qtspData.name)
+            .thenReturn(mockedQtspName)
+        whenever(optionsSelectionInteractor.getQtsps())
+            .thenReturn(response)
     }
 
     private suspend fun mockGetServiceAuthorizationUrlCall(response: EudiRqesGetServiceAuthorizationUrlPartialState) {


### PR DESCRIPTION
# Description of changes
- Ensured that the selected index for QTSPs and certificates is correctly passed and used when displaying the bottom sheets
- Refactored `OptionsSelectionViewModel` to extract bottom sheet display logic into new methods: `showSelectQtspBottomSheet` and `showSelectCertificateBottomSheet`.
- Updated `TestOptionsSelectionViewModel` to mock the `getQtsps` call and verify correct bottom sheet display and index selection.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable