### PR TITLE
Refactor: Update `getSignedDocumentsCache` to return `File`

### DIFF
--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/controller/RqesController.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/domain/controller/RqesController.kt
@@ -538,7 +538,7 @@ internal class RqesControllerImpl(
                     authFlowRedirectionURI = qtspData.authFlowRedirectionURI,
                     tsaurl = qtspData.tsaUrl,
                 ),
-                outputPathDir = resourceProvider.getSignedDocumentsCache(),
+                outputPathDir = resourceProvider.getSignedDocumentsCache().absolutePath,
                 hashAlgorithm = qtspData.hashAlgorithm
             )
             eudiRQESUi.setRqesService(service)

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/provider/ResourceProvider.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/provider/ResourceProvider.kt
@@ -36,7 +36,7 @@ internal interface ResourceProvider {
     fun genericErrorMessage(): String
     fun genericServiceErrorMessage(): String
     fun getLocalizedString(localizableKey: LocalizableKey, args: List<String> = emptyList()): String
-    fun getSignedDocumentsCache(): String
+    fun getSignedDocumentsCache(): File
 
     fun getDownloadsCache(): File
 }
@@ -94,12 +94,12 @@ internal class ResourceProviderImpl(
         return localizationController.get(localizableKey, args)
     }
 
-    override fun getSignedDocumentsCache(): String = File(
+    override fun getSignedDocumentsCache(): File = File(
         context.cacheDir,
         "signed_pdfs"
     ).apply {
         mkdirs()
-    }.absolutePath
+    }
 
     override fun getDownloadsCache(): File =
         File(context.cacheDir, "downloads").apply { mkdirs() }

--- a/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/controller/TestRqesController.kt
+++ b/rqes-ui-sdk/src/test/java/eu/europa/ec/eudi/rqesui/domain/controller/TestRqesController.kt
@@ -129,7 +129,7 @@ class TestRqesController {
         whenever(resourceProvider.genericErrorTitle())
             .thenReturn(mockedGenericErrorTitle)
         whenever(resourceProvider.getSignedDocumentsCache())
-            .thenReturn(RuntimeEnvironment.getApplication().cacheDir.absolutePath)
+            .thenReturn(RuntimeEnvironment.getApplication().cacheDir)
     }
 
     @After


### PR DESCRIPTION
The `ResourceProvider.getSignedDocumentsCache()` method and its implementation `AndroidResourceProvider.getSignedDocumentsCache()` now return a `File` object instead of a `String` representing the absolute path.

This change simplifies the usage of the cache directory. Callers now directly receive the `File` object, and the `.absolutePath` is accessed where needed (e.g., in `RqesController.createRqesService`).

Unit tests in `TestRqesController` have been updated to reflect this change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable