### PR TITLE
Enable edge-to-edge display in `TestRQESActivity`

### DIFF
--- a/test-app/src/main/java/eu/europa/ec/eudi/testrqes/ui/TestRQESActivity.kt
+++ b/test-app/src/main/java/eu/europa/ec/eudi/testrqes/ui/TestRQESActivity.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -61,10 +62,13 @@ class TestRQESActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             EudiRQESUiTheme {
                 checkIntent(intent)
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                Scaffold(
+                    modifier = Modifier.fillMaxSize()
+                ) { innerPadding ->
                     Content(innerPadding)
                 }
             }
@@ -73,7 +77,6 @@ class TestRQESActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-
         checkIntent(intent)
     }
 
@@ -102,7 +105,7 @@ private fun Content(padding: PaddingValues) {
         }
 
         var remoteUri by remember {
-            mutableStateOf<String>("")
+            mutableStateOf("")
         }
 
         val selectPdfLauncher = rememberLauncherForActivityResult(


### PR DESCRIPTION
This commit enables edge-to-edge display for the `TestRQESActivity` by calling `enableEdgeToEdge()` in the `onCreate` method. It also includes minor code cleanup, such as removing an unnecessary empty line and simplifying a `mutableStateOf` initialization.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable