### PR TITLE
Refactor: Rename `forcedBottomPadding` to `screenPaddingsIgnoringSticky`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
-# Description of changes
-Add a description of the change here
-
 ## Type of change
 
 Please delete options that are not relevant.

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
@@ -179,7 +179,7 @@ internal fun ContentScreen(
 
         ) { padding ->
 
-        val forcedBottomPadding = remember(padding) {
+        val screenPaddingsIgnoringSticky = remember(padding) {
             screenPaddings(hasStickyBottom = false, append = padding)
         }
 
@@ -190,7 +190,7 @@ internal fun ContentScreen(
             if (contentErrorConfig != null) {
                 ContentError(
                     config = contentErrorConfig,
-                    paddingValues = forcedBottomPadding
+                    paddingValues = screenPaddingsIgnoringSticky
                 )
             } else {
                 Column(modifier = Modifier.fillMaxSize()) {
@@ -214,7 +214,7 @@ internal fun ContentScreen(
                         ) {
                             stickyBottomContent(
                                 stickyBottomPaddings(
-                                    contentScreenPaddings = forcedBottomPadding,
+                                    contentScreenPaddings = screenPaddingsIgnoringSticky,
                                     layoutDirection = LocalLayoutDirection.current
                                 )
                             )


### PR DESCRIPTION
The variable `forcedBottomPadding` in `ContentScreen.kt` has been renamed to `screenPaddingsIgnoringSticky` for better clarity. This change improves the readability of the code by more accurately describing the purpose of the variable, which is to hold screen paddings when there is no sticky bottom content.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable