### PR TITLE
Refactor: Update fastlane test command and Java toolchain

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,7 @@ default_platform(:android)
 platform :android do
 
 desc "Runs all the tests"
-lane :test do
+lane :tests do
   gradle(task: "clean")
   gradle(task: "rqes-ui-sdk:koverHtmlReportDebug")
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -15,10 +15,10 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 ## Android
 
-### android test
+### android tests
 
 ```sh
-[bundle exec] fastlane android test
+[bundle exec] fastlane android tests
 ```
 
 Runs all the tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,6 +29,9 @@ VERSION_NAME=0.3.1
 NAMESPACE=eu.europa.ec.eudi.rqesui
 GROUP=eu.europa.ec.eudi
 
+# VERSIONS
+toolChainResolverVersion=1.0.0
+
 # PUBLISH PROPERTIES
 SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=false

--- a/rqes-ui-sdk/build.gradle.kts
+++ b/rqes-ui-sdk/build.gradle.kts
@@ -72,6 +72,15 @@ android {
             jvmTarget.set(JvmTarget.JVM_17)
         }
     }
+
+    val toolchains = extensions.getByType<JavaToolchainService>()
+    tasks.withType<Test>().configureEach {
+        javaLauncher.set(
+            toolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(21))
+            }
+        )
+    }
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,10 @@
  */
 
 pluginManagement {
+    val toolChainResolverVersion: String by extra
+    plugins {
+        id("org.gradle.toolchains.foojay-resolver-convention") version toolChainResolverVersion
+    }
     repositories {
         google {
             content {


### PR DESCRIPTION
This commit includes the following changes:

- **fastlane**:
    - Renamed the `test` lane to `tests` in `Fastfile`.
    - Updated the corresponding command in `fastlane/README.md`.
- **Gradle**:
    - Added the `foojay-resolver-convention` plugin in `settings.gradle.kts` for managing Java toolchains.
    - Configured tests in `rqes-ui-sdk/build.gradle.kts` to use Java 21 via the toolchain.
    - Added `toolChainResolverVersion` to `gradle.properties`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable