### PR TITLE
Update AGP to 8.12.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 eudiRqesCore = "0.3.0"
-agp = "8.12.1"
+agp = "8.12.2"
 kotlin = "2.2.10"
 kotlinxCoroutines = "1.10.2"
 coreKtx = "1.17.0"


### PR DESCRIPTION
This commit updates the Android Gradle Plugin (AGP) version from 8.12.1 to 8.12.2 in the `gradle/libs.versions.toml` file.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable