### PR TITLE
Fix: Apply navigation bar padding to sticky button

### DIFF
--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/content/ContentScreen.kt
@@ -199,6 +199,7 @@ internal fun ContentScreen(
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .navigationBarsPadding()
                                 .zIndex(Z_STICKY),
                             contentAlignment = Alignment.Center
                         ) {

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/utils/ScreenPadding.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/presentation/ui/component/utils/ScreenPadding.kt
@@ -52,7 +52,7 @@ internal fun stickyBottomPaddings(
         start = contentScreenPaddings.calculateStartPadding(layoutDirection),
         end = contentScreenPaddings.calculateEndPadding(layoutDirection),
         top = BOTTOM_SCREEN_PADDING.dp,
-        bottom = contentScreenPaddings.calculateBottomPadding()
+        bottom = BOTTOM_SCREEN_PADDING.dp
     )
 }
 


### PR DESCRIPTION
This commit applies navigation bar padding to the sticky button in `ContentScreen.kt` to prevent it from overlapping with the navigation bar.

It also updates `ScreenPadding.kt` to ensure consistent bottom padding.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable