### PR TITLE
feat: Add Material 3 fixed accent colors and update dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,10 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
-androidxNavigation = "2.9.4"
-composeBom = "2025.09.00"
+androidxNavigation = "2.9.5"
+composeBom = "2025.09.01"
 appcompat = "1.7.1"
-material3 = "1.3.2"
+material3 = "1.4.0"
 material = "1.13.0"
 timber = "5.0.1"
 androidxSecurity = "1.1.0"
@@ -21,13 +21,13 @@ koinAnnotations = "2.1.0"
 ksp = "2.2.20-2.0.3"
 gson = "2.13.2"
 mavenPublish = "0.34.0"
-mockito = "5.19.0"
-mockitoKotlin = "6.0.0"
+mockito = "5.20.0"
+mockitoKotlin = "6.1.0"
 kover = "0.9.2"
 robolectric = "4.16"
 turbine = "1.2.1"
 pdfViewer = "2.0.1"
-owaspDependencyCheck = "12.1.3"
+owaspDependencyCheck = "12.1.6"
 
 [libraries]
 eudi-lib-android-rqes-core = { module = "eu.europa.ec.eudi:eudi-lib-android-rqes-core", version.ref = "eudiRqesCore" }
@@ -47,6 +47,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 androidx-security = { group = "androidx.security", name = "security-crypto", version.ref = "androidxSecurity" }

--- a/rqes-ui-sdk/build.gradle.kts
+++ b/rqes-ui-sdk/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.ui.tooling)
+    api(libs.androidx.compose.material.iconsExtended)
 
     // Koin
     api(libs.koin.android)

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/theme/templates/ThemeColorsTemplate.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/theme/templates/ThemeColorsTemplate.kt
@@ -60,6 +60,18 @@ data class ThemeColorsTemplate(
     val surfaceContainerHighest: Long,
     val surfaceContainerLow: Long,
     val surfaceContainerLowest: Long,
+    val primaryFixed: Long,
+    val primaryFixedDim: Long,
+    val onPrimaryFixed: Long,
+    val onPrimaryFixedVariant: Long,
+    val secondaryFixed: Long,
+    val secondaryFixedDim: Long,
+    val onSecondaryFixed: Long,
+    val onSecondaryFixedVariant: Long,
+    val tertiaryFixed: Long,
+    val tertiaryFixedDim: Long,
+    val onTertiaryFixed: Long,
+    val onTertiaryFixedVariant: Long
 ) {
     companion object {
         fun ThemeColorsTemplate.toColorScheme(): ColorScheme = ColorScheme(
@@ -98,7 +110,19 @@ data class ThemeColorsTemplate(
             surfaceContainerHigh = Color(surfaceContainerHigh),
             surfaceContainerHighest = Color(surfaceContainerHighest),
             surfaceContainerLow = Color(surfaceContainerLow),
-            surfaceContainerLowest = Color(surfaceContainerLowest)
+            surfaceContainerLowest = Color(surfaceContainerLowest),
+            primaryFixed = Color(primaryFixed),
+            primaryFixedDim = Color(primaryFixedDim),
+            onPrimaryFixed = Color(onPrimaryFixed),
+            onPrimaryFixedVariant = Color(onPrimaryFixedVariant),
+            secondaryFixed = Color(secondaryFixed),
+            secondaryFixedDim = Color(secondaryFixedDim),
+            onSecondaryFixed = Color(onSecondaryFixed),
+            onSecondaryFixedVariant = Color(onSecondaryFixedVariant),
+            tertiaryFixed = Color(tertiaryFixed),
+            tertiaryFixedDim = Color(tertiaryFixed),
+            onTertiaryFixed = Color(onTertiaryFixed),
+            onTertiaryFixedVariant = Color(onTertiaryFixedVariant)
         )
     }
 }

--- a/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/theme/values/ThemeColors.kt
+++ b/rqes-ui-sdk/src/main/java/eu/europa/ec/eudi/rqesui/infrastructure/theme/values/ThemeColors.kt
@@ -72,6 +72,22 @@ internal class ThemeColors {
         private const val EudiRQESUi_theme_light_surfaceContainerHighest: Long = 0xFFE6E0E9
         private const val EudiRQESUi_theme_light_surfaceTint: Long = EudiRQESUi_theme_light_surface
 
+        // Light theme fixed accent roles (identical in dark as well).
+        private const val eudiw_theme_light_primaryFixed: Long = 0xFFD4DEF7
+        private const val eudiw_theme_light_primaryFixedDim: Long = 0xFFA8BEF0
+        private const val eudiw_theme_light_onPrimaryFixed: Long = 0xFF08122B
+        private const val eudiw_theme_light_onPrimaryFixedVariant: Long = 0xFF173782
+
+        private const val eudiw_theme_light_secondaryFixed: Long = 0xFFD3D6F8
+        private const val eudiw_theme_light_secondaryFixedDim: Long = 0xFFA6ADF2
+        private const val eudiw_theme_light_onSecondaryFixed: Long = 0xFF070A2C
+        private const val eudiw_theme_light_onSecondaryFixedVariant: Long = 0xFF141D85
+
+        private const val eudiw_theme_light_tertiaryFixed: Long = 0xFFE0EBE3
+        private const val eudiw_theme_light_tertiaryFixedDim: Long = 0xFFC0D8C7
+        private const val eudiw_theme_light_onTertiaryFixed: Long = 0xFF141F17
+        private const val eudiw_theme_light_onTertiaryFixedVariant: Long = 0xFF3B5E46
+
         // Light theme extra colors palette.
         internal const val EudiRQESUi_theme_light_success: Long = 0xFF55953B
         internal const val EudiRQESUi_theme_light_warning: Long = 0xFFAB5200
@@ -115,6 +131,22 @@ internal class ThemeColors {
         private const val EudiRQESUi_theme_dark_surfaceContainerHigh: Long = 0xFF2A2A2A
         private const val EudiRQESUi_theme_dark_surfaceContainerHighest: Long = 0xFF353535
         private const val EudiRQESUi_theme_dark_surfaceTint: Long = EudiRQESUi_theme_dark_surface
+
+        // Dark theme fixed accent roles (same values as light).
+        private const val eudiw_theme_dark_primaryFixed: Long = 0xFFD4DEF7
+        private const val eudiw_theme_dark_primaryFixedDim: Long = 0xFFA8BEF0
+        private const val eudiw_theme_dark_onPrimaryFixed: Long = 0xFF08122B
+        private const val eudiw_theme_dark_onPrimaryFixedVariant: Long = 0xFF173782
+
+        private const val eudiw_theme_dark_secondaryFixed: Long = 0xFFD3D6F8
+        private const val eudiw_theme_dark_secondaryFixedDim: Long = 0xFFA6ADF2
+        private const val eudiw_theme_dark_onSecondaryFixed: Long = 0xFF070A2C
+        private const val eudiw_theme_dark_onSecondaryFixedVariant: Long = 0xFF141D85
+
+        private const val eudiw_theme_dark_tertiaryFixed: Long = 0xFFE0EBE3
+        private const val eudiw_theme_dark_tertiaryFixedDim: Long = 0xFFC0D8C7
+        private const val eudiw_theme_dark_onTertiaryFixed: Long = 0xFF141F17
+        private const val eudiw_theme_dark_onTertiaryFixedVariant: Long = 0xFF3B5E46
 
         // Dark theme extra colors palette.
         internal const val EudiRQESUi_theme_dark_success: Long = 0xFF93D875
@@ -164,6 +196,18 @@ internal class ThemeColors {
             surfaceContainerHighest = EudiRQESUi_theme_light_surfaceContainerHighest,
             surfaceContainerLow = EudiRQESUi_theme_light_surfaceContainerLow,
             surfaceContainerLowest = EudiRQESUi_theme_light_surfaceContainerLowest,
+            primaryFixed = eudiw_theme_light_primaryFixed,
+            primaryFixedDim = eudiw_theme_light_primaryFixedDim,
+            onPrimaryFixed = eudiw_theme_light_onPrimaryFixed,
+            onPrimaryFixedVariant = eudiw_theme_light_onPrimaryFixedVariant,
+            secondaryFixed = eudiw_theme_light_secondaryFixed,
+            secondaryFixedDim = eudiw_theme_light_secondaryFixedDim,
+            onSecondaryFixed = eudiw_theme_light_onSecondaryFixed,
+            onSecondaryFixedVariant = eudiw_theme_light_onSecondaryFixedVariant,
+            tertiaryFixed = eudiw_theme_light_tertiaryFixed,
+            tertiaryFixedDim = eudiw_theme_light_tertiaryFixedDim,
+            onTertiaryFixed = eudiw_theme_light_onTertiaryFixed,
+            onTertiaryFixedVariant = eudiw_theme_light_onTertiaryFixedVariant
         )
 
         internal val darkColors = ThemeColorsTemplate(
@@ -203,6 +247,18 @@ internal class ThemeColors {
             surfaceContainerHighest = EudiRQESUi_theme_dark_surfaceContainerHighest,
             surfaceContainerLow = EudiRQESUi_theme_dark_surfaceContainerLow,
             surfaceContainerLowest = EudiRQESUi_theme_dark_surfaceContainerLowest,
+            primaryFixed = eudiw_theme_dark_primaryFixed,
+            primaryFixedDim = eudiw_theme_dark_primaryFixedDim,
+            onPrimaryFixed = eudiw_theme_dark_onPrimaryFixed,
+            onPrimaryFixedVariant = eudiw_theme_dark_onPrimaryFixedVariant,
+            secondaryFixed = eudiw_theme_dark_secondaryFixed,
+            secondaryFixedDim = eudiw_theme_dark_secondaryFixedDim,
+            onSecondaryFixed = eudiw_theme_dark_onSecondaryFixed,
+            onSecondaryFixedVariant = eudiw_theme_dark_onSecondaryFixedVariant,
+            tertiaryFixed = eudiw_theme_dark_tertiaryFixed,
+            tertiaryFixedDim = eudiw_theme_dark_tertiaryFixedDim,
+            onTertiaryFixed = eudiw_theme_dark_onTertiaryFixed,
+            onTertiaryFixedVariant = eudiw_theme_dark_onTertiaryFixedVariant,
         )
 
         internal val success: Color


### PR DESCRIPTION
This commit introduces Material 3 fixed accent color roles and updates several dependencies.

- **Dependencies**:
    - Updated various libraries in `gradle/libs.versions.toml`, including: - `androidxNavigation`: `2.9.4` -> `2.9.5` - `composeBom`: `2025.09.00` -> `2025.09.01` - `material3`: `1.3.2` -> `1.4.0` - `mockito`: `5.19.0` -> `5.20.0` - `mockitoKotlin`: `6.0.0` -> `6.1.0` - `owaspDependencyCheck`: `12.1.3` -> `12.1.6`
    - Added `androidx.compose.material.iconsExtended` as an API dependency in `rqes-ui-sdk/build.gradle.kts`.

- **Theme**:
    - Added fixed accent colors (`primaryFixed`, `secondaryFixed`, `tertiaryFixed`, and their variants) to `ThemeColorsTemplate.kt` and the corresponding color scheme mapping.
    - Defined the new fixed accent color values for both light and dark themes in `ThemeColors.kt`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable