### PR TITLE
chore: Update actions/checkout to v7 in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       code-version: ${{ steps.extract.outputs.CODE_VERSION }}
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: actions/setup-java@v5
         with:
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       code-version: ${{ steps.extract.outputs.CODE_VERSION }}
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - id: extract
         name: Extract code version from gradle.properties
         run: echo "CODE_VERSION=$(awk -F= '$1~/VERSION_NAME/{print $2}' gradle.properties)" >> $GITHUB_OUTPUT
@@ -27,7 +27,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'


### PR DESCRIPTION
This commit updates the version of the `actions/checkout` GitHub Action from `v6` to `v7` across the project's workflow configurations.

- **CI Workflow**: Updated `actions/checkout` to `v7` in both the `setup` and `build` jobs.
- **Release Workflow**: Updated `actions/checkout` to `v7` in both the `setup` and `publish` jobs.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other fix (maintenance or house-keeping)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [ ] I have checked that my strings are *localized* where applicable
- [ ] I have checked that no secrets, signing material, or production credentials are committed
- [ ] I have checked that no unintended demo endpoints or demo trust anchors are used by production code
- [ ] I have considered the security and privacy impact of this change
- [ ] I have tested or reviewed the release build behavior where applicable
